### PR TITLE
CNTRLPLANE-211: Update Dockerfile.ci to align with Konflux Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,16 +1,21 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as builder
 WORKDIR /go/src/github.com/openshift/lws-operator
 COPY . .
+RUN make build --warn-undefined-variables
 
-RUN make build
-
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.19
+FROM registry.ci.openshift.org/ocp/builder:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/lws-operator/lws-operator /usr/bin/
-COPY --from=builder /go/src/github.com/openshift/lws-operator/manifests/* /manifests/
+RUN mkdir /licenses
+COPY --from=builder /go/src/github.com/openshift/lws-operator/LICENSE /licenses/.
 
-LABEL io.k8s.display-name="Leader Worker Set" \
-      io.k8s.description="This is a component of OpenShift and manages the leader worker set" \
+LABEL com.redhat.component="Leader Worker Set"
+LABEL description="LeaderWorkerSet Operator manages the Leader Worker Set."
+LABEL name="lws-operator"
+LABEL summary="LeaderWorkerSet Operator manages the Leader Worker Set."
+LABEL io.k8s.display-name="LeaderWorkerSet Operator" \
+      io.k8s.description="This is an operator to manage Leader Worker Set" \
       io.openshift.tags="openshift,lws-operator" \
       com.redhat.delivery.appregistry=true \
       maintainer="AOS workloads team, <aos-workloads-staff@redhat.com>"
+USER 1001
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ generate-controller-manifests:
 	hack/update-lws-controller-manifests.sh
 .PHONY: generate-controller-manifests
 
+verify-codegen:
+	hack/verify-codegen.sh
+.PHONY: verify-codegen
+
 verify-controller-manifests:
 	hack/verify-lws-controller-manifests.sh
 .PHONY: verify-controller-manifests


### PR DESCRIPTION
This PR updates Dockerfile.ci to align with Konflux Dockerfile. They should be identical with only an exception that base images should differ.