### PR TITLE
CNTRLPLANE-211: Modify GOFLAGS to use -mod=readonly instead of -mod=vendor

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -3,7 +3,7 @@ WORKDIR /go/src/github.com/openshift/lws-operator
 COPY . .
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/builder:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/lws-operator/lws-operator /usr/bin/
 RUN mkdir /licenses
 COPY --from=builder /go/src/github.com/openshift/lws-operator/LICENSE /licenses/.

--- a/hack/update-lws-controller-manifests.sh
+++ b/hack/update-lws-controller-manifests.sh
@@ -27,7 +27,7 @@ LWS_NAMESPACE="${LWS_NAMESPACE:-openshift-lws-operator}"
 # Ensure yq is installed
 if ! command -v yq &> /dev/null; then
     echo "yq is not installed. Installing yq..."
-    go install github.com/mikefarah/yq/v4@v4.45.1
+    go install -mod=readonly github.com/mikefarah/yq/v4@v4.45.1
 fi
 
 if [ ! -d "${LWS_CONTROLLER_DIR}" ]; then
@@ -45,7 +45,7 @@ pushd "${LWS_CONTROLLER_DIR}"
       exit 2
   fi
   # ensure kustomize exists or download it
-  make kustomize
+  GOFLAGS='-mod=readonly' make kustomize
 
   ORIGINAL_GIT_BRANCH_OR_COMMIT="$(git branch --show-current)"
   if [[ -z "${ORIGINAL_GIT_BRANCH_OR_COMMIT}" ]]; then

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -36,7 +36,6 @@ cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
-cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
 if [[ $ret -eq 0 ]]
 then
   echo "${DIFFROOT} up to date."


### PR DESCRIPTION
Our CI system sets `GOFLAGS='-mod=vendor'` by default. Therefore, any CI job that tries to install a tool that is used to test something rather than modifying the go.mod fails by raising `cannot query module due to -mod=vendor` error.

This PR modifies the GOFLAGS to `-mod=readonly` to install these binaries.

Ref: https://go.dev/ref/mod

* -mod=readonly tells the go command to ignore the vendor directory and to report an error if go.mod needs to be updated.
* -mod=vendor tells the go command to use the vendor directory. In this mode, the go command will not use the network or the module cache.

