### PR TITLE
NO-JIRA: Set LWSOperator CRD as cluster scoped

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ $(call verify-golang-versions,Dockerfile)
 regen-crd:
 	go build -o _output/tools/bin/controller-gen ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 	rm manifests/leaderworkerset-operator.crd.yaml
-	./_output/tools/bin/controller-gen crd paths=./pkg/apis/leaderworkersetoperator/v1/... schemapatch:manifests=./manifests output:crd:dir=./manifests
+	./_output/tools/bin/controller-gen crd paths=./pkg/apis/leaderworkersetoperator/v1/... output:crd:dir=./manifests
 	mv manifests/operator.openshift.io_leaderworkersetoperators.yaml manifests/leaderworkerset-operator.crd.yaml
-	cp manifests/operator.openshift.io_leaderworkersetoperators.yaml deploy/00_lws-operator.crd.yaml
+	cp manifests/leaderworkerset-operator.crd.yaml deploy/00_lws-operator.crd.yaml
 
-generate: regen-crd generate-clients generate-controller-manifests
+generate: generate-clients regen-crd generate-controller-manifests
 .PHONY: generate
 
 generate-clients:

--- a/deploy/00_lws-operator.crd.yaml
+++ b/deploy/00_lws-operator.crd.yaml
@@ -12,196 +12,196 @@ spec:
     listKind: LeaderWorkerSetOperatorList
     plural: leaderworkersetoperators
     singular: leaderworkersetoperator
-  scope: Namespaced
+  scope: Cluster
   versions:
-    - name: v1
-      schema:
-        openAPIV3Schema:
-          description: LeaderWorkerSetOperator is the Schema for the LeaderWorkerSetOperator
-            API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: spec holds user settable values for configuration
-              properties:
-                logLevel:
-                  default: Normal
-                  description: |-
-                    logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a
-                    simple way to manage coarse grained logging choices that operators have to interpret for their operands.
-                    
-                    Valid values are: "Normal", "Debug", "Trace", "TraceAll".
-                    Defaults to "Normal".
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                  type: string
-                managementState:
-                  description: managementState indicates whether and how the operator
-                    should manage the component
-                  pattern: ^(Managed|Unmanaged|Force|Removed)$
-                  type: string
-                observedConfig:
-                  description: |-
-                    observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because
-                    it is an input to the level for the operator
-                  nullable: true
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LeaderWorkerSetOperator is the Schema for the LeaderWorkerSetOperator
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec holds user settable values for configuration
+            properties:
+              logLevel:
+                default: Normal
+                description: |-
+                  logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a
+                  simple way to manage coarse grained logging choices that operators have to interpret for their operands.
+
+                  Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  Defaults to "Normal".
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              managementState:
+                description: managementState indicates whether and how the operator
+                  should manage the component
+                pattern: ^(Managed|Unmanaged|Force|Removed)$
+                type: string
+              observedConfig:
+                description: |-
+                  observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because
+                  it is an input to the level for the operator
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              operatorLogLevel:
+                default: Normal
+                description: |-
+                  operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a
+                  simple way to manage coarse grained logging choices that operators have to interpret for themselves.
+
+                  Valid values are: "Normal", "Debug", "Trace", "TraceAll".
+                  Defaults to "Normal".
+                enum:
+                - ""
+                - Normal
+                - Debug
+                - Trace
+                - TraceAll
+                type: string
+              unsupportedConfigOverrides:
+                description: |-
+                  unsupportedConfigOverrides overrides the final configuration that was computed by the operator.
+                  Red Hat does not support the use of this field.
+                  Misuse of this field could lead to unexpected behavior or conflict with other configuration options.
+                  Seek guidance from the Red Hat support before using this field.
+                  Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
+                nullable: true
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: status holds observed values from the cluster. They may not
+              be overridden.
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: OperatorCondition is just the standard condition fields.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
-                operatorLogLevel:
-                  default: Normal
-                  description: |-
-                    operatorLogLevel is an intent based logging for the operator itself.  It does not give fine grained control, but it is a
-                    simple way to manage coarse grained logging choices that operators have to interpret for themselves.
-                    
-                    Valid values are: "Normal", "Debug", "Trace", "TraceAll".
-                    Defaults to "Normal".
-                  enum:
-                    - ""
-                    - Normal
-                    - Debug
-                    - Trace
-                    - TraceAll
-                  type: string
-                unsupportedConfigOverrides:
-                  description: |-
-                    unsupportedConfigOverrides overrides the final configuration that was computed by the operator.
-                    Red Hat does not support the use of this field.
-                    Misuse of this field could lead to unexpected behavior or conflict with other configuration options.
-                    Seek guidance from the Red Hat support before using this field.
-                    Use of this property blocks cluster upgrades, it must be removed before upgrading your cluster.
-                  nullable: true
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              generations:
+                description: generations are used to determine when an item needs
+                  to be reconciled or has changed in a way that needs a reaction.
+                items:
+                  description: GenerationStatus keeps track of the generation for
+                    a given resource so that decisions about forced updates can be
+                    made.
+                  properties:
+                    group:
+                      description: group is the group of the thing you're tracking
+                      type: string
+                    hash:
+                      description: hash is an optional field set for resources without
+                        generation that are content sensitive like secrets and configmaps
+                      type: string
+                    lastGeneration:
+                      description: lastGeneration is the last generation of the workload
+                        controller involved
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the name of the thing you're tracking
+                      type: string
+                    namespace:
+                      description: namespace is where the thing you're tracking is
+                      type: string
+                    resource:
+                      description: resource is the resource type of the thing you're
+                        tracking
+                      type: string
+                  required:
+                  - group
+                  - name
+                  - namespace
+                  - resource
                   type: object
-                  x-kubernetes-preserve-unknown-fields: true
-              type: object
-            status:
-              description: status holds observed values from the cluster. They may not
-                be overridden.
-              properties:
-                conditions:
-                  description: conditions is a list of conditions and their status
-                  items:
-                    description: OperatorCondition is just the standard condition fields.
-                    properties:
-                      lastTransitionTime:
-                        description: |-
-                          lastTransitionTime is the last time the condition transitioned from one status to another.
-                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                        format: date-time
-                        type: string
-                      message:
-                        type: string
-                      reason:
-                        type: string
-                      status:
-                        description: status of the condition, one of True, False, Unknown.
-                        enum:
-                          - "True"
-                          - "False"
-                          - Unknown
-                        type: string
-                      type:
-                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        maxLength: 316
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                        type: string
-                    required:
-                      - lastTransitionTime
-                      - status
-                      - type
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - type
-                  x-kubernetes-list-type: map
-                generations:
-                  description: generations are used to determine when an item needs
-                    to be reconciled or has changed in a way that needs a reaction.
-                  items:
-                    description: GenerationStatus keeps track of the generation for
-                      a given resource so that decisions about forced updates can be
-                      made.
-                    properties:
-                      group:
-                        description: group is the group of the thing you're tracking
-                        type: string
-                      hash:
-                        description: hash is an optional field set for resources without
-                          generation that are content sensitive like secrets and configmaps
-                        type: string
-                      lastGeneration:
-                        description: lastGeneration is the last generation of the workload
-                          controller involved
-                        format: int64
-                        type: integer
-                      name:
-                        description: name is the name of the thing you're tracking
-                        type: string
-                      namespace:
-                        description: namespace is where the thing you're tracking is
-                        type: string
-                      resource:
-                        description: resource is the resource type of the thing you're
-                          tracking
-                        type: string
-                    required:
-                      - group
-                      - name
-                      - namespace
-                      - resource
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                    - group
-                    - resource
-                    - namespace
-                    - name
-                  x-kubernetes-list-type: map
-                latestAvailableRevision:
-                  description: latestAvailableRevision is the deploymentID of the most
-                    recent deployment
-                  format: int32
-                  type: integer
-                  x-kubernetes-validations:
-                    - message: must only increase
-                      rule: self >= oldSelf
-                observedGeneration:
-                  description: observedGeneration is the last generation change you've
-                    dealt with
-                  format: int64
-                  type: integer
-                readyReplicas:
-                  description: readyReplicas indicates how many replicas are ready and
-                    at the desired state
-                  format: int32
-                  type: integer
-                version:
-                  description: version is the level this availability applies to
-                  type: string
-              type: object
-          required:
-            - spec
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: array
+                x-kubernetes-list-map-keys:
+                - group
+                - resource
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+              latestAvailableRevision:
+                description: latestAvailableRevision is the deploymentID of the most
+                  recent deployment
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must only increase
+                  rule: self >= oldSelf
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas indicates how many replicas are ready and
+                  at the desired state
+                format: int32
+                type: integer
+              version:
+                description: version is the level this availability applies to
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/07_lws-operator.cr.yaml
+++ b/deploy/07_lws-operator.cr.yaml
@@ -2,7 +2,6 @@ apiVersion: operator.openshift.io/v1
 kind: LeaderWorkerSetOperator
 metadata:
   name: cluster
-  namespace: openshift-lws-operator
 spec:
   managementState: Managed
   logLevel: Normal

--- a/manifests/leaderworkerset-operator.crd.yaml
+++ b/manifests/leaderworkerset-operator.crd.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: LeaderWorkerSetOperatorList
     plural: leaderworkersetoperators
     singular: leaderworkersetoperator
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/pkg/apis/leaderworkersetoperator/v1/types.go
+++ b/pkg/apis/leaderworkersetoperator/v1/types.go
@@ -10,8 +10,10 @@ import (
 // LeaderWorkerSetOperator is the Schema for the LeaderWorkerSetOperator API
 // +k8s:openapi-gen=true
 // +genclient
+// +genclient:nonNamespaced
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster
 type LeaderWorkerSetOperator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/generated/applyconfiguration/leaderworkersetoperator/v1/leaderworkersetoperator.go
+++ b/pkg/generated/applyconfiguration/leaderworkersetoperator/v1/leaderworkersetoperator.go
@@ -36,10 +36,9 @@ type LeaderWorkerSetOperatorApplyConfiguration struct {
 
 // LeaderWorkerSetOperator constructs a declarative configuration of the LeaderWorkerSetOperator type for use with
 // apply.
-func LeaderWorkerSetOperator(name, namespace string) *LeaderWorkerSetOperatorApplyConfiguration {
+func LeaderWorkerSetOperator(name string) *LeaderWorkerSetOperatorApplyConfiguration {
 	b := &LeaderWorkerSetOperatorApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("LeaderWorkerSetOperator")
 	b.WithAPIVersion("operator.openshift.io/v1")
 	return b
@@ -74,7 +73,6 @@ func extractLeaderWorkerSetOperator(leaderWorkerSetOperator *leaderworkersetoper
 		return nil, err
 	}
 	b.WithName(leaderWorkerSetOperator.Name)
-	b.WithNamespace(leaderWorkerSetOperator.Namespace)
 
 	b.WithKind("LeaderWorkerSetOperator")
 	b.WithAPIVersion("operator.openshift.io/v1")

--- a/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/fake/fake_leaderworkersetoperator.go
+++ b/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/fake/fake_leaderworkersetoperator.go
@@ -29,11 +29,11 @@ type fakeLeaderWorkerSetOperators struct {
 	Fake *FakeOpenShiftOperatorV1
 }
 
-func newFakeLeaderWorkerSetOperators(fake *FakeOpenShiftOperatorV1, namespace string) typedleaderworkersetoperatorv1.LeaderWorkerSetOperatorInterface {
+func newFakeLeaderWorkerSetOperators(fake *FakeOpenShiftOperatorV1) typedleaderworkersetoperatorv1.LeaderWorkerSetOperatorInterface {
 	return &fakeLeaderWorkerSetOperators{
 		gentype.NewFakeClientWithListAndApply[*v1.LeaderWorkerSetOperator, *v1.LeaderWorkerSetOperatorList, *leaderworkersetoperatorv1.LeaderWorkerSetOperatorApplyConfiguration](
 			fake.Fake,
-			namespace,
+			"",
 			v1.SchemeGroupVersion.WithResource("leaderworkersetoperators"),
 			v1.SchemeGroupVersion.WithKind("LeaderWorkerSetOperator"),
 			func() *v1.LeaderWorkerSetOperator { return &v1.LeaderWorkerSetOperator{} },

--- a/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/fake/fake_leaderworkersetoperator_client.go
+++ b/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/fake/fake_leaderworkersetoperator_client.go
@@ -26,8 +26,8 @@ type FakeOpenShiftOperatorV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeOpenShiftOperatorV1) LeaderWorkerSetOperators(namespace string) v1.LeaderWorkerSetOperatorInterface {
-	return newFakeLeaderWorkerSetOperators(c, namespace)
+func (c *FakeOpenShiftOperatorV1) LeaderWorkerSetOperators() v1.LeaderWorkerSetOperatorInterface {
+	return newFakeLeaderWorkerSetOperators(c)
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/leaderworkersetoperator.go
+++ b/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/leaderworkersetoperator.go
@@ -31,7 +31,7 @@ import (
 // LeaderWorkerSetOperatorsGetter has a method to return a LeaderWorkerSetOperatorInterface.
 // A group's client should implement this interface.
 type LeaderWorkerSetOperatorsGetter interface {
-	LeaderWorkerSetOperators(namespace string) LeaderWorkerSetOperatorInterface
+	LeaderWorkerSetOperators() LeaderWorkerSetOperatorInterface
 }
 
 // LeaderWorkerSetOperatorInterface has methods to work with LeaderWorkerSetOperator resources.
@@ -58,13 +58,13 @@ type leaderWorkerSetOperators struct {
 }
 
 // newLeaderWorkerSetOperators returns a LeaderWorkerSetOperators
-func newLeaderWorkerSetOperators(c *OpenShiftOperatorV1Client, namespace string) *leaderWorkerSetOperators {
+func newLeaderWorkerSetOperators(c *OpenShiftOperatorV1Client) *leaderWorkerSetOperators {
 	return &leaderWorkerSetOperators{
 		gentype.NewClientWithListAndApply[*leaderworkersetoperatorv1.LeaderWorkerSetOperator, *leaderworkersetoperatorv1.LeaderWorkerSetOperatorList, *applyconfigurationleaderworkersetoperatorv1.LeaderWorkerSetOperatorApplyConfiguration](
 			"leaderworkersetoperators",
 			c.RESTClient(),
 			scheme.ParameterCodec,
-			namespace,
+			"",
 			func() *leaderworkersetoperatorv1.LeaderWorkerSetOperator {
 				return &leaderworkersetoperatorv1.LeaderWorkerSetOperator{}
 			},

--- a/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/leaderworkersetoperator_client.go
+++ b/pkg/generated/clientset/versioned/typed/leaderworkersetoperator/v1/leaderworkersetoperator_client.go
@@ -34,8 +34,8 @@ type OpenShiftOperatorV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *OpenShiftOperatorV1Client) LeaderWorkerSetOperators(namespace string) LeaderWorkerSetOperatorInterface {
-	return newLeaderWorkerSetOperators(c, namespace)
+func (c *OpenShiftOperatorV1Client) LeaderWorkerSetOperators() LeaderWorkerSetOperatorInterface {
+	return newLeaderWorkerSetOperators(c)
 }
 
 // NewForConfig creates a new OpenShiftOperatorV1Client for the given config.

--- a/pkg/generated/informers/externalversions/leaderworkersetoperator/v1/interface.go
+++ b/pkg/generated/informers/externalversions/leaderworkersetoperator/v1/interface.go
@@ -39,5 +39,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // LeaderWorkerSetOperators returns a LeaderWorkerSetOperatorInformer.
 func (v *version) LeaderWorkerSetOperators() LeaderWorkerSetOperatorInformer {
-	return &leaderWorkerSetOperatorInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &leaderWorkerSetOperatorInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/generated/informers/externalversions/leaderworkersetoperator/v1/leaderworkersetoperator.go
+++ b/pkg/generated/informers/externalversions/leaderworkersetoperator/v1/leaderworkersetoperator.go
@@ -40,33 +40,32 @@ type LeaderWorkerSetOperatorInformer interface {
 type leaderWorkerSetOperatorInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewLeaderWorkerSetOperatorInformer constructs a new informer for LeaderWorkerSetOperator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewLeaderWorkerSetOperatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredLeaderWorkerSetOperatorInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewLeaderWorkerSetOperatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredLeaderWorkerSetOperatorInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredLeaderWorkerSetOperatorInformer constructs a new informer for LeaderWorkerSetOperator type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredLeaderWorkerSetOperatorInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredLeaderWorkerSetOperatorInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenShiftOperatorV1().LeaderWorkerSetOperators(namespace).List(context.TODO(), options)
+				return client.OpenShiftOperatorV1().LeaderWorkerSetOperators().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.OpenShiftOperatorV1().LeaderWorkerSetOperators(namespace).Watch(context.TODO(), options)
+				return client.OpenShiftOperatorV1().LeaderWorkerSetOperators().Watch(context.TODO(), options)
 			},
 		},
 		&apisleaderworkersetoperatorv1.LeaderWorkerSetOperator{},
@@ -76,7 +75,7 @@ func NewFilteredLeaderWorkerSetOperatorInformer(client versioned.Interface, name
 }
 
 func (f *leaderWorkerSetOperatorInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredLeaderWorkerSetOperatorInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredLeaderWorkerSetOperatorInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *leaderWorkerSetOperatorInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/generated/listers/leaderworkersetoperator/v1/expansion_generated.go
+++ b/pkg/generated/listers/leaderworkersetoperator/v1/expansion_generated.go
@@ -19,7 +19,3 @@ package v1
 // LeaderWorkerSetOperatorListerExpansion allows custom methods to be added to
 // LeaderWorkerSetOperatorLister.
 type LeaderWorkerSetOperatorListerExpansion interface{}
-
-// LeaderWorkerSetOperatorNamespaceListerExpansion allows custom methods to be added to
-// LeaderWorkerSetOperatorNamespaceLister.
-type LeaderWorkerSetOperatorNamespaceListerExpansion interface{}

--- a/pkg/generated/listers/leaderworkersetoperator/v1/leaderworkersetoperator.go
+++ b/pkg/generated/listers/leaderworkersetoperator/v1/leaderworkersetoperator.go
@@ -29,8 +29,9 @@ type LeaderWorkerSetOperatorLister interface {
 	// List lists all LeaderWorkerSetOperators in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*leaderworkersetoperatorv1.LeaderWorkerSetOperator, err error)
-	// LeaderWorkerSetOperators returns an object that can list and get LeaderWorkerSetOperators.
-	LeaderWorkerSetOperators(namespace string) LeaderWorkerSetOperatorNamespaceLister
+	// Get retrieves the LeaderWorkerSetOperator from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*leaderworkersetoperatorv1.LeaderWorkerSetOperator, error)
 	LeaderWorkerSetOperatorListerExpansion
 }
 
@@ -42,27 +43,4 @@ type leaderWorkerSetOperatorLister struct {
 // NewLeaderWorkerSetOperatorLister returns a new LeaderWorkerSetOperatorLister.
 func NewLeaderWorkerSetOperatorLister(indexer cache.Indexer) LeaderWorkerSetOperatorLister {
 	return &leaderWorkerSetOperatorLister{listers.New[*leaderworkersetoperatorv1.LeaderWorkerSetOperator](indexer, leaderworkersetoperatorv1.Resource("leaderworkersetoperator"))}
-}
-
-// LeaderWorkerSetOperators returns an object that can list and get LeaderWorkerSetOperators.
-func (s *leaderWorkerSetOperatorLister) LeaderWorkerSetOperators(namespace string) LeaderWorkerSetOperatorNamespaceLister {
-	return leaderWorkerSetOperatorNamespaceLister{listers.NewNamespaced[*leaderworkersetoperatorv1.LeaderWorkerSetOperator](s.ResourceIndexer, namespace)}
-}
-
-// LeaderWorkerSetOperatorNamespaceLister helps list and get LeaderWorkerSetOperators.
-// All objects returned here must be treated as read-only.
-type LeaderWorkerSetOperatorNamespaceLister interface {
-	// List lists all LeaderWorkerSetOperators in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*leaderworkersetoperatorv1.LeaderWorkerSetOperator, err error)
-	// Get retrieves the LeaderWorkerSetOperator from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*leaderworkersetoperatorv1.LeaderWorkerSetOperator, error)
-	LeaderWorkerSetOperatorNamespaceListerExpansion
-}
-
-// leaderWorkerSetOperatorNamespaceLister implements the LeaderWorkerSetOperatorNamespaceLister
-// interface.
-type leaderWorkerSetOperatorNamespaceLister struct {
-	listers.ResourceIndexer[*leaderworkersetoperatorv1.LeaderWorkerSetOperator]
 }

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -27,11 +27,10 @@ const OperatorConfigName = "cluster"
 var _ v1helpers.OperatorClient = &LeaderWorkerSetClient{}
 
 type LeaderWorkerSetClient struct {
-	Ctx               context.Context
-	SharedInformer    cache.SharedIndexInformer
-	OperatorClient    leaderworkersetoperatorinterface.OpenShiftOperatorV1Interface
-	Lister            leaderworkersetoperatorlisterv1.LeaderWorkerSetOperatorLister
-	OperatorNamespace string
+	Ctx            context.Context
+	SharedInformer cache.SharedIndexInformer
+	OperatorClient leaderworkersetoperatorinterface.OpenShiftOperatorV1Interface
+	Lister         leaderworkersetoperatorlisterv1.LeaderWorkerSetOperatorLister
 }
 
 func (l *LeaderWorkerSetClient) Informer() cache.SharedIndexInformer {
@@ -41,12 +40,12 @@ func (l *LeaderWorkerSetClient) Informer() cache.SharedIndexInformer {
 func (l *LeaderWorkerSetClient) GetObjectMeta() (meta *metav1.ObjectMeta, err error) {
 	var instance *leaderworkersetoperatorapiv1.LeaderWorkerSetOperator
 	if l.SharedInformer.HasSynced() {
-		instance, err = l.Lister.LeaderWorkerSetOperators(l.OperatorNamespace).Get(OperatorConfigName)
+		instance, err = l.Lister.Get(OperatorConfigName)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		instance, err = l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Get(l.Ctx, OperatorConfigName, metav1.GetOptions{})
+		instance, err = l.OperatorClient.LeaderWorkerSetOperators().Get(l.Ctx, OperatorConfigName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -58,7 +57,7 @@ func (l *LeaderWorkerSetClient) GetOperatorState() (spec *operatorv1.OperatorSpe
 	if !l.SharedInformer.HasSynced() {
 		return l.GetOperatorStateWithQuorum(l.Ctx)
 	}
-	instance, err := l.Lister.LeaderWorkerSetOperators(l.OperatorNamespace).Get(OperatorConfigName)
+	instance, err := l.Lister.Get(OperatorConfigName)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -66,7 +65,7 @@ func (l *LeaderWorkerSetClient) GetOperatorState() (spec *operatorv1.OperatorSpe
 }
 
 func (l *LeaderWorkerSetClient) GetOperatorStateWithQuorum(ctx context.Context) (spec *operatorv1.OperatorSpec, status *operatorv1.OperatorStatus, resourceVersion string, err error) {
-	instance, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := l.OperatorClient.LeaderWorkerSetOperators().Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -74,13 +73,13 @@ func (l *LeaderWorkerSetClient) GetOperatorStateWithQuorum(ctx context.Context) 
 }
 
 func (l *LeaderWorkerSetClient) UpdateOperatorSpec(ctx context.Context, resourceVersion string, in *operatorv1.OperatorSpec) (out *operatorv1.OperatorSpec, newResourceVersion string, err error) {
-	original, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{ResourceVersion: resourceVersion})
+	original, err := l.OperatorClient.LeaderWorkerSetOperators().Get(ctx, OperatorConfigName, metav1.GetOptions{ResourceVersion: resourceVersion})
 	if err != nil {
 		return nil, "", err
 	}
 	original.Spec.OperatorSpec = *in
 
-	ret, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Update(ctx, original, metav1.UpdateOptions{})
+	ret, err := l.OperatorClient.LeaderWorkerSetOperators().Update(ctx, original, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, "", err
 	}
@@ -89,13 +88,13 @@ func (l *LeaderWorkerSetClient) UpdateOperatorSpec(ctx context.Context, resource
 }
 
 func (l *LeaderWorkerSetClient) UpdateOperatorStatus(ctx context.Context, resourceVersion string, in *operatorv1.OperatorStatus) (out *operatorv1.OperatorStatus, err error) {
-	original, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{ResourceVersion: resourceVersion})
+	original, err := l.OperatorClient.LeaderWorkerSetOperators().Get(ctx, OperatorConfigName, metav1.GetOptions{ResourceVersion: resourceVersion})
 	if err != nil {
 		return nil, err
 	}
 	original.Status.OperatorStatus = *in
 
-	ret, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).UpdateStatus(ctx, original, metav1.UpdateOptions{})
+	ret, err := l.OperatorClient.LeaderWorkerSetOperators().UpdateStatus(ctx, original, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +109,10 @@ func (l *LeaderWorkerSetClient) ApplyOperatorSpec(ctx context.Context, fieldMana
 	desiredSpec := &leaderworkersetoperatorv1.LeaderWorkerSetOperatorSpecApplyConfiguration{
 		OperatorSpecApplyConfiguration: *applyConfiguration,
 	}
-	desired := leaderworkersetoperatorv1.LeaderWorkerSetOperator(OperatorConfigName, l.OperatorNamespace)
+	desired := leaderworkersetoperatorv1.LeaderWorkerSetOperator(OperatorConfigName)
 	desired.WithSpec(desiredSpec)
 
-	instance, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := l.OperatorClient.LeaderWorkerSetOperators().Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 	// do nothing and proceed with the apply
@@ -129,7 +128,7 @@ func (l *LeaderWorkerSetClient) ApplyOperatorSpec(ctx context.Context, fieldMana
 		}
 	}
 
-	_, err = l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Apply(ctx, desired, metav1.ApplyOptions{
+	_, err = l.OperatorClient.LeaderWorkerSetOperators().Apply(ctx, desired, metav1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
@@ -148,10 +147,10 @@ func (l *LeaderWorkerSetClient) ApplyOperatorStatus(ctx context.Context, fieldMa
 	desiredStatus := &leaderworkersetoperatorv1.LeaderWorkerSetOperatorStatusApplyConfiguration{
 		OperatorStatusApplyConfiguration: *applyConfiguration,
 	}
-	desired := leaderworkersetoperatorv1.LeaderWorkerSetOperator(OperatorConfigName, l.OperatorNamespace)
+	desired := leaderworkersetoperatorv1.LeaderWorkerSetOperator(OperatorConfigName)
 	desired.WithStatus(desiredStatus)
 
-	instance, err := l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Get(ctx, OperatorConfigName, metav1.GetOptions{})
+	instance, err := l.OperatorClient.LeaderWorkerSetOperators().Get(ctx, OperatorConfigName, metav1.GetOptions{})
 	switch {
 	case apierrors.IsNotFound(err):
 		// do nothing and proceed with the apply
@@ -173,7 +172,7 @@ func (l *LeaderWorkerSetClient) ApplyOperatorStatus(ctx context.Context, fieldMa
 		}
 	}
 
-	_, err = l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).ApplyStatus(ctx, desired, metav1.ApplyOptions{
+	_, err = l.OperatorClient.LeaderWorkerSetOperators().ApplyStatus(ctx, desired, metav1.ApplyOptions{
 		Force:        true,
 		FieldManager: fieldManager,
 	})
@@ -189,6 +188,6 @@ func (l *LeaderWorkerSetClient) PatchOperatorStatus(ctx context.Context, jsonPat
 	if err != nil {
 		return err
 	}
-	_, err = l.OperatorClient.LeaderWorkerSetOperators(l.OperatorNamespace).Patch(ctx, OperatorConfigName, types.JSONPatchType, jsonPatchBytes, metav1.PatchOptions{}, "/status")
+	_, err = l.OperatorClient.LeaderWorkerSetOperators().Patch(ctx, OperatorConfigName, types.JSONPatchType, jsonPatchBytes, metav1.PatchOptions{}, "/status")
 	return err
 }

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -63,17 +63,16 @@ func RunOperator(ctx context.Context, cc *controllercmd.ControllerContext) error
 	)
 
 	leaderWorkerSetOperatorClient := &operatorclient.LeaderWorkerSetClient{
-		Ctx:               ctx,
-		SharedInformer:    operatorConfigInformers.OpenShiftOperator().V1().LeaderWorkerSetOperators().Informer(),
-		Lister:            operatorConfigInformers.OpenShiftOperator().V1().LeaderWorkerSetOperators().Lister(),
-		OperatorClient:    operatorConfigClient.OpenShiftOperatorV1(),
-		OperatorNamespace: namespace,
+		Ctx:            ctx,
+		SharedInformer: operatorConfigInformers.OpenShiftOperator().V1().LeaderWorkerSetOperators().Informer(),
+		Lister:         operatorConfigInformers.OpenShiftOperator().V1().LeaderWorkerSetOperators().Lister(),
+		OperatorClient: operatorConfigClient.OpenShiftOperatorV1(),
 	}
 
 	targetConfigReconciler := NewTargetConfigReconciler(
 		os.Getenv("RELATED_IMAGE_OPERAND_IMAGE"),
 		namespace,
-		operatorConfigClient.OpenShiftOperatorV1().LeaderWorkerSetOperators(namespace),
+		operatorConfigClient.OpenShiftOperatorV1().LeaderWorkerSetOperators(),
 		operatorConfigInformers.OpenShiftOperator().V1().LeaderWorkerSetOperators(),
 		kubeInformersForNamespaces,
 		leaderWorkerSetOperatorClient,


### PR DESCRIPTION
This PR sets LWSOperator CRD as cluster scoped and reacts to the changes in operator implementation accordingly.