### PR TITLE
NO-JIRA: Use staging registry for lws to test the release

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -2,7 +2,9 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as bui
 WORKDIR /go/src/github.com/openshift/lws-operator
 COPY . .
 
-ARG OPERAND_IMAGE=registry.redhat.io/leader-worker-set/lws-rhel9@sha256:c745da3f1d39662600a6a1d4453f7fd5a5743f2ea9857cef60c5721c25beb482
+# lws is not in snapshot. So that Konflux warns us about the inaccessibility of the image.
+# We need to use staging. This must be correct to registry.redhat.io, when the bundle is released to prod.
+ARG OPERAND_IMAGE=registry.stage.redhat.io/leader-worker-set/lws-rhel9@sha256:c6c825ba5bf39ab1e2e38190bef3f3d40eef3702ffb372ccf973e31aec043e80
 ARG REPLACED_OPERAND_IMG=\${OPERAND_IMAGE}
 
 # Replace the operand image in deploy/05_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.


### PR DESCRIPTION
Konflux build process needs to access the images inside the bundle ContainerFile. This can either be the direct access to the image or image is inaccessible by default but it is released in the same snapshot with bundle ContainerFile (i.e. operator is in the same snapshot of the bundle Containerfile). 

We had to discriminate the operand image due to release the same versions aligning with the upstream (0.7 version of the image corresponds to 0.7 upstream LWS) which does not match the operator and bundle image version whose will be released in 1.0 version.

As a result, in bundle image, we'll have to use operand image from staging registry. Once we are ready to release production, this needs to be manually updated to prod registry.