### PR TITLE
Revert "NO-JIRA: Use staging registry for lws to test the release"

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -2,9 +2,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as bui
 WORKDIR /go/src/github.com/openshift/lws-operator
 COPY . .
 
-# lws is not in snapshot. So that Konflux warns us about the inaccessibility of the image.
-# We need to use staging. This must be correct to registry.redhat.io, when the bundle is released to prod.
-ARG OPERAND_IMAGE=registry.stage.redhat.io/leader-worker-set/lws-rhel9@sha256:c6c825ba5bf39ab1e2e38190bef3f3d40eef3702ffb372ccf973e31aec043e80
+ARG OPERAND_IMAGE=registry.redhat.io/leader-worker-set/lws-rhel9@sha256:c745da3f1d39662600a6a1d4453f7fd5a5743f2ea9857cef60c5721c25beb482
 ARG REPLACED_OPERAND_IMG=\${OPERAND_IMAGE}
 
 # Replace the operand image in deploy/05_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.


### PR DESCRIPTION
Reverts openshift/lws-operator#82

I'm not comfortable with this change.