### PR TITLE
NO-JIRA: Disable sast-coverity-check

### DIFF
--- a/.tekton/lws-operator-bundle-main-pull-request.yaml
+++ b/.tekton/lws-operator-bundle-main-pull-request.yaml
@@ -419,55 +419,55 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-coverity-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - coverity-availability-check
-      taskRef:
-        params:
-        - name: name
-          value: sast-coverity-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      - input: $(tasks.coverity-availability-check.results.STATUS)
-        operator: in
-        values:
-        - success
+#    - name: sast-coverity-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      runAfter:
+#      - coverity-availability-check
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-coverity-check-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#      - input: $(tasks.coverity-availability-check.results.STATUS)
+#        operator: in
+#        values:
+#        - success
     - name: coverity-availability-check
       runAfter:
       - build-image-index

--- a/.tekton/lws-operator-bundle-main-push.yaml
+++ b/.tekton/lws-operator-bundle-main-push.yaml
@@ -416,55 +416,55 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-coverity-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - coverity-availability-check
-      taskRef:
-        params:
-        - name: name
-          value: sast-coverity-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      - input: $(tasks.coverity-availability-check.results.STATUS)
-        operator: in
-        values:
-        - success
+#    - name: sast-coverity-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      runAfter:
+#      - coverity-availability-check
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-coverity-check-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#      - input: $(tasks.coverity-availability-check.results.STATUS)
+#        operator: in
+#        values:
+#        - success
     - name: coverity-availability-check
       runAfter:
       - build-image-index

--- a/.tekton/lws-operator-main-pull-request.yaml
+++ b/.tekton/lws-operator-main-pull-request.yaml
@@ -445,55 +445,55 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-coverity-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - coverity-availability-check
-      taskRef:
-        params:
-        - name: name
-          value: sast-coverity-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      - input: $(tasks.coverity-availability-check.results.STATUS)
-        operator: in
-        values:
-        - success
+#    - name: sast-coverity-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      runAfter:
+#      - coverity-availability-check
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-coverity-check-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#      - input: $(tasks.coverity-availability-check.results.STATUS)
+#        operator: in
+#        values:
+#        - success
     - name: coverity-availability-check
       runAfter:
       - build-image-index

--- a/.tekton/lws-operator-main-push.yaml
+++ b/.tekton/lws-operator-main-push.yaml
@@ -442,55 +442,55 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-coverity-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - coverity-availability-check
-      taskRef:
-        params:
-        - name: name
-          value: sast-coverity-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-      - input: $(tasks.coverity-availability-check.results.STATUS)
-        operator: in
-        values:
-        - success
+#    - name: sast-coverity-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      runAfter:
+#      - coverity-availability-check
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-coverity-check-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:f9ca942208dc2e63b479384ccc56a611cc793397ecc837637b5b9f89c2ecbefe
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#      - input: $(tasks.coverity-availability-check.results.STATUS)
+#        operator: in
+#        values:
+#        - success
     - name: coverity-availability-check
       runAfter:
       - build-image-index


### PR DESCRIPTION
sast-coverity-check is very flaky which causes waste of time and effort while waiting for the success of retries. This optional task is a blocker for us. 

This PR removes this task from the pipeline.