### PR TITLE
NO-JIRA: Revert "Update lws-1-0 to 7dfb657"

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -2,7 +2,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.23 as bui
 WORKDIR /go/src/github.com/openshift/lws-operator
 COPY . .
 
-ARG OPERAND_IMAGE=registry.redhat.io/leader-worker-set/lws-rhel9@sha256:7dfb657f548b071f9551b3507dd4b95cc7aab29206249a9bd604516c12c8c1fc
+ARG OPERAND_IMAGE=registry.redhat.io/leader-worker-set/lws-rhel9@sha256:affb303b1173c273231bb50fef07310b0e220d2f08bfc0aa5912d0825e3e0d4f
 ARG REPLACED_OPERAND_IMG=\${OPERAND_IMAGE}
 
 # Replace the operand image in deploy/05_deployment.yaml with the one specified by the OPERAND_IMAGE build argument.


### PR DESCRIPTION
We must revert this to point to legitimate lws image to release. Once we are done, we can revert this revert.