### PR TITLE
NO-JIRA:Add  managementState automation test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -33,11 +33,13 @@ import (
 
 	v1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/openshift/lws-operator/test/e2e/testutils"
 )
 
 const (
 	operatorNamespace = "openshift-lws-operator"
 	operandLabel      = "control-plane=controller-manager"
+	OperandName       = "lws-controller-manager"
 )
 
 var _ = Describe("LWS Operator", Ordered, func() {
@@ -126,5 +128,45 @@ var _ = Describe("LWS Operator", Ordered, func() {
 			return true, nil
 		})
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow manual scaling when managementState is Unmanaged", func() {
+		ctx := context.TODO()
+		By("Fetching initial operator state")
+		lwsOperator, originalState, err := testutils.GetOperatorState(ctx, clients)
+		Expect(err).ShouldNot(HaveOccurred())
+		originalPodCount := testutils.GetPodCount(ctx, clients, operatorNamespace, operandLabel)
+
+		defer func() {
+			testutils.SetManagementState(ctx, clients, lwsOperator, originalState)
+			testutils.VerifyPodCount(ctx, clients, operatorNamespace, operandLabel, originalPodCount)
+		}()
+		By("Setting managementState to Unmanaged")
+		testutils.SetManagementState(ctx, clients, lwsOperator, v1.Unmanaged)
+
+		By("Scaling up to 3 replicas")
+		testutils.ScaleDeployment(ctx, clients, OperandName, 3)
+		testutils.VerifyPodCount(ctx, clients, operatorNamespace, operandLabel, 3)
+	})
+
+	It("when managementState is Removed test", func() {
+		//note: Now we keep lws-controller-manager according to actual senarios"
+		ctx := context.TODO()
+		By("Fetching initial operator state")
+		lwsOperator, originalState, err := testutils.GetOperatorState(ctx, clients)
+		Expect(err).ShouldNot(HaveOccurred())
+		originalPodCount := testutils.GetPodCount(ctx, clients, operatorNamespace, operandLabel)
+
+		defer func() {
+			newctx := context.TODO()
+			testutils.SetManagementState(newctx, clients, lwsOperator, originalState)
+			testutils.VerifyPodCount(newctx, clients, operatorNamespace, operandLabel, originalPodCount)
+		}()
+		By("Setting managementState to Removed")
+		testutils.SetManagementState(ctx, clients, lwsOperator, v1.Removed)
+
+		By("Scaling up to 3 replicas")
+		testutils.ScaleDeployment(ctx, clients, OperandName, 3)
+		testutils.VerifyPodCount(ctx, clients, operatorNamespace, operandLabel, 3)
 	})
 })

--- a/test/e2e/testutils/utils.go
+++ b/test/e2e/testutils/utils.go
@@ -1,0 +1,78 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/onsi/gomega"
+	v1 "github.com/openshift/api/operator/v1"
+	operatorv1 "github.com/openshift/lws-operator/pkg/apis/leaderworkersetoperator/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+)
+
+const (
+	operatorNamespace = "openshift-lws-operator"
+	OperandName       = "lws-controller-manager"
+)
+
+func GetOperatorState(ctx context.Context, clients *TestClients) (*operatorv1.LeaderWorkerSetOperator, v1.ManagementState, error) {
+	if clients == nil || clients.LWSOperatorClient == nil {
+		return nil, "", fmt.Errorf("nil clients or LWSOperatorClient")
+	}
+	lwsOperator, err := clients.LWSOperatorClient.Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get operator: %w", err)
+	}
+
+	return lwsOperator, lwsOperator.Spec.ManagementState, nil
+}
+
+func SetManagementState(ctx context.Context, clients *TestClients, operator *operatorv1.LeaderWorkerSetOperator, state v1.ManagementState) {
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		current, getErr := clients.LWSOperatorClient.Get(ctx, operator.Name, metav1.GetOptions{})
+		if getErr != nil {
+			return getErr
+		}
+		current.Spec.ManagementState = state
+		_, updateErr := clients.LWSOperatorClient.Update(ctx, current, metav1.UpdateOptions{})
+		return updateErr
+	})
+	gomega.Expect(retryErr).NotTo(gomega.HaveOccurred(), "failed to update operator state after retries")
+}
+
+func ScaleDeployment(ctx context.Context, clients *TestClients, OperandName string, replicas int32) {
+	patch := fmt.Sprintf(`{"spec":{"replicas":%d}}`, replicas)
+	_, err := clients.KubeClient.AppsV1().Deployments(operatorNamespace).Patch(
+		ctx,
+		OperandName,
+		types.StrategicMergePatchType,
+		[]byte(patch),
+		metav1.PatchOptions{})
+	if err != nil {
+		klog.Errorf("WARNING: Failed to restore replicas: %v\n", err)
+	}
+}
+
+func VerifyPodCount(ctx context.Context, clients *TestClients, namespace, labelSelector string, expected int) {
+	gomega.Eventually(func() int {
+		return GetPodCount(ctx, clients, namespace, labelSelector)
+	}, 5*time.Minute, 10*time.Second).Should(
+		gomega.Equal(expected),
+		"Pod count should reach %d", expected)
+}
+
+func GetPodCount(ctx context.Context, clients *TestClients, namespace, labelSelector string) int {
+	pods, err := clients.KubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		klog.Errorf("Pod list error: %v\n", err)
+		return -1
+	}
+	return len(pods.Items)
+}


### PR DESCRIPTION
Pass log:
```
------------------------------
LWS Operator should allow manual scaling when managementState is Unmanaged
/home/wewang/lws-operator/test/e2e/e2e_test.go:133
  STEP: Fetching initial operator state @ 09/16/25 09:45:39.129
  STEP: Setting managementState to Unmanaged @ 09/16/25 09:45:40.26
  STEP: Scaling up to 3 replicas @ 09/16/25 09:45:41.008
• [57.411 seconds]
------------------------------
LWS Operator when managementState is Removed test
/home/wewang/lws-operator/test/e2e/e2e_test.go:152
  STEP: Fetching initial operator state @ 09/16/25 09:46:36.54
  STEP: Setting managementState to Removed @ 09/16/25 09:46:37.477
  STEP: Scaling up to 3 replicas @ 09/16/25 09:46:38.28
• [14.750 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.002 seconds]
------------------------------

Ran 4 of 4 Specs in 80.110 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 1m22.005863877s
Test Suite Passed
```
