### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for lws-operator-bundle-1-0

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -35,14 +35,14 @@ COPY --from=builder /go/src/github.com/openshift/lws-operator/metadata /metadata
 COPY --from=builder /go/src/github.com/openshift/lws-operator/licenses /licenses
 
 LABEL com.redhat.component="Leader Worker Set"
+LABEL cpe="cpe:/a:redhat:leader_worker_set:1.0::el9"
 LABEL description="Red Hat build of Leader Worker Set is based on the [LWS](https://lws.sigs.k8s.io/docs/) open source project. LeaderWorkerSet: An API for deploying a group of pods as a unit of replication. It aims to address common deployment patterns of AI/ML inference workloads, especially multi-host inference workloads where the LLM will be sharded and run across multiple devices on multiple nodes."
 LABEL distribution-scope="public"
-LABEL name="lws-operator-bundle"
+LABEL name="leader-worker-set/lws-operator-bundle"
 LABEL release="1.0.0"
 LABEL version="1.0.0"
 LABEL url="https://github.com/openshift/lws-operator"
 LABEL vendor="Red Hat, Inc."
-LABEL name="lws-operator-bundle"
 LABEL summary="LeaderWorkerSet: An API for deploying a group of pods as a unit of replication"
 LABEL io.k8s.display-name="Leader Worker Set" \
       io.k8s.description="This is an operator to manage Leader Worker Set" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
