### PR TITLE
NO-JIRA: Fix incorrect IDMS ApiVersion

### DIFF
--- a/.tekton/images-mirror-set.yaml
+++ b/.tekton/images-mirror-set.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: operator.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1
 kind: ImageDigestMirrorSet
 metadata:
   name: lws-operator-mirror-set


### PR DESCRIPTION
It looks like IDMS resource's ApiVersion field is incorrectly set. This PR mimics https://github.com/openshift/lws-operator/pull/225