### PR TITLE
NO-JIRA: Typo: missing camel case in "OpenShift"

### DIFF
--- a/manifests/leader-worker-set.clusterserviceversion.yaml
+++ b/manifests/leader-worker-set.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.34.2
     repository: https://github.com/openshift/lws-operator
     support: Red Hat, Inc.
-    categories: Openshift Optional
+    categories: OpenShift Optional
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"


### PR DESCRIPTION
Leads to adding an extra category in Operator Hub:

<img width="1308" height="627" alt="Screen Shot 2025-11-10 at 11 03 58" src="https://github.com/user-attachments/assets/1a3ac53c-c788-4b18-81ac-085016de5a9d" />
