### PR TITLE
NO-JIRA: add v4.21 to lws

### DIFF
--- a/generate-fbc.sh
+++ b/generate-fbc.sh
@@ -1,3 +1,3 @@
-for OCP_VERSION in v4.18 v4.19 v4.20; do
+for OCP_VERSION in v4.18 v4.19 v4.20 v4.21; do
     opm alpha render-template semver $OCP_VERSION/catalog-template.yaml --migrate-level=bundle-object-to-csv-metadata > $OCP_VERSION/catalog/lws-operator/catalog.json;
 done

--- a/v4.21/Containerfile.catalog
+++ b/v4.21/Containerfile.catalog
@@ -1,0 +1,21 @@
+# The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY catalog/ /configs
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Core bundle labels.
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=leader-worker-set
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.2
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1

--- a/v4.21/catalog-template.yaml
+++ b/v4.21/catalog-template.yaml
@@ -1,0 +1,7 @@
+Schema: olm.semver
+GenerateMajorChannels: false
+GenerateMinorChannels: true
+DefaultChannelTypePreference: "minor"
+Stable:
+  Bundles:
+    - Image: registry.redhat.io/leader-worker-set/lws-operator-bundle@sha256:f641cf3b2d6659e26eb0ae49c67a3416152a2fbc2f26f490889a2bd169b9ea06

--- a/v4.21/catalog/lws-operator/catalog.json
+++ b/v4.21/catalog/lws-operator/catalog.json
@@ -1,0 +1,145 @@
+{
+    "schema": "olm.package",
+    "name": "leader-worker-set",
+    "defaultChannel": "stable-v1.0"
+}
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.0",
+    "package": "leader-worker-set",
+    "entries": [
+        {
+            "name": "leader-worker-set.v1.0.0"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "leader-worker-set.v1.0.0",
+    "package": "leader-worker-set",
+    "image": "registry.redhat.io/leader-worker-set/lws-operator-bundle@sha256:f641cf3b2d6659e26eb0ae49c67a3416152a2fbc2f26f490889a2bd169b9ea06",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "operator.openshift.io",
+                "kind": "LeaderWorkerSetOperator",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "leader-worker-set",
+                "version": "1.0.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"operator.openshift.io/v1\",\n    \"kind\": \"LeaderWorkerSetOperator\",\n    \"metadata\": {\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"logLevel\": \"Normal\",\n      \"managementState\": \"Managed\",\n      \"operatorLogLevel\": \"Normal\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "categories": "Openshift Optional",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2025-04-14T08:12:51Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-lws-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.34.2",
+                    "repository": "https://github.com/openshift/lws-operator",
+                    "support": "Red Hat, Inc."
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "leaderworkersetoperators.operator.openshift.io",
+                            "version": "v1",
+                            "kind": "LeaderWorkerSetOperator"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Leader Worker Set is based on the [LWS](https://lws.sigs.k8s.io/docs/) open source project.\nLeader Worker Set: An API for deploying a group of pods as a unit of replication. \nIt aims to address common deployment patterns of AI/ML inference workloads, \nespecially multi-host inference workloads where the LLM will be sharded and run across multiple devices on multiple nodes.\n",
+                "displayName": "Red Hat build of Leader Worker Set",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": true
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": false
+                    }
+                ],
+                "keywords": [
+                    "leader-worker-set"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Leader Worker Set",
+                        "url": "https://lws.sigs.k8s.io/docs/overview/"
+                    },
+                    {
+                        "name": "Operand Source Code",
+                        "url": "https://github.com/openshift/kubernetes-sigs-lws"
+                    },
+                    {
+                        "name": "Operator Source Code",
+                        "url": "https://github.com/openshift/lws-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Red Hat",
+                        "email": "support@redhat.com"
+                    }
+                ],
+                "maturity": "alpha",
+                "minKubeVersion": "1.30.0",
+                "provider": {
+                    "name": "Red Hat",
+                    "url": "https://github.com/openshift/lws-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "",
+            "image": "registry.redhat.io/leader-worker-set/lws-operator-bundle@sha256:f641cf3b2d6659e26eb0ae49c67a3416152a2fbc2f26f490889a2bd169b9ea06"
+        },
+        {
+            "name": "lws-operator",
+            "image": "registry.redhat.io/leader-worker-set/lws-rhel9-operator@sha256:c202bfa15626262ff22682b64ac57539d28dd35f5960c490f5afea75cef34309"
+        },
+        {
+            "name": "lws",
+            "image": "registry.redhat.io/leader-worker-set/lws-rhel9@sha256:affb303b1173c273231bb50fef07310b0e220d2f08bfc0aa5912d0825e3e0d4f"
+        }
+    ]
+}


### PR DESCRIPTION
Similar reason as https://github.com/openshift/jobset-operator/pull/191.

I'd like to get lws/jobset in the 4.21 catalog.