### PR TITLE
NO-JIRA: Add control-plane-approvers to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,5 @@
 reviewers:
-  - ardaguclu
-  - atiratree
+  - control-plane-approvers
 approvers:
-  - ardaguclu
-  - atiratree
+  - control-plane-approvers
 component: "lws-operator"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,16 @@
+aliases:
+  control-plane-approvers:
+    - ardaguclu
+    - atiratree
+    - benluddy
+    - bertinatto
+    - everettraven
+    - flavianmissi
+    - gangwgr
+    - ingvagabund
+    - kaleemsiddiqu
+    - p0lyn0mial
+    - rh-roman
+    - ricardomaraschini
+    - tjungblu
+    - xueqzhan


### PR DESCRIPTION
Add control-plane-approvers to OWNERS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review team assignments for the lws-operator component to use a centralized reviewer group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->