### PR TITLE
NO-JIRA: Updating the releases table to show support for LWS 1.0.0 for OCP 4.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The LeaderWorkerSet Operator provides the ability to deploy a
 
 | lws version | ocp version | k8s version | golang |
 |-------------|-------------|-------------|--------|
-| 1.0.0       | 4.18-4.21   | 1.33        | 1.24   |
+| 1.0.0       | 4.18-4.22   | 1.33        | 1.24   |
 
 ## Deploy the Operator
 


### PR DESCRIPTION
Updating the releases table to show that LWS 1.0.0 will be supported on OCP 4.22 too (per slack convo with @ardaguclu)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenShift Container Platform compatibility for LWS 1.0.0 to support versions 4.18 through 4.22.
  * Corrected markdown formatting in test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->