### PR TITLE
CNTRLPLANE-3869: Add NetworkPolicy RBAC to LWS operator

### DIFF
--- a/deploy/03_00_role.yaml
+++ b/deploy/03_00_role.yaml
@@ -70,4 +70,16 @@ rules:
       - list
       - patch
       - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 

--- a/manifests/leader-worker-set.clusterserviceversion.yaml
+++ b/manifests/leader-worker-set.clusterserviceversion.yaml
@@ -339,6 +339,18 @@ spec:
                 - patch
                 - update
             - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - ""
               resources:
                 - configmaps


### PR DESCRIPTION
[CNTRLPLANE-3869](https://redhat.atlassian.net/browse/CNTRLPLANE-3869): Add NetworkPolicy RBAC to LWS operator

```
Without fix we see network policy warning

ec validate image \
    --image registry.redhat.io/leader-worker-set/lws-operator-bundle@sha256:f641cf3b2d6659e26eb0ae49c67a3416152a2fbc2f26f490889a2bd169b9ea06 \
    --policy '{"sources":[{"policy":["oci::quay.io/enterprise-contract/ec-release-policy:latest"]}]}' \
    --ignore-rekor \
    --skip-image-sig-check \
    --skip-att-sig-check \
    --certificate-identity-regexp '.*' \
    --certificate-oidc-issuer-regexp '.*' \
    --output text \
    --strict false \
    --info

[Warning] olm.required_network_policy_rbac_for_operands
  ImageRef: registry.redhat.io/leader-worker-set/lws-operator-bundle@sha256:f641cf3b2d6659e26eb0ae49c67a3416152a2fbc2f26f490889a2bd169b9ea06
  Reason: Operator "leader-worker-set" version "1.0.0" is missing required NetworkPolicy RBAC (networking.k8s.io/networkpolicies
  with create, delete, and update/patch)
  Title: NetworkPolicy RBAC present in OLM bundle
  Description: Operators are required to manage the network policies of their operands. This rule verifies that operator bundles
  request sufficient RBAC permissions to manage NetworkPolicy lifecycle (create, delete, and update/patch) for
  networking.k8s.io/networkpolicies in their ClusterServiceVersion. Bundles whose operator name and major.minor version are listed
  in the `operator_network_policy_rbac_exceptions` rule data key are exempt from this requirement.
  Solution: Add a rule granting create, delete, and update/patch on networking.k8s.io/networkpolicies to the ClusterServiceVersion
  clusterPermissions or permissions, or add the operator name and its major.minor version to the
  operator_network_policy_rbac_exceptions rule data key.


With fix we  didn't see network policy warnings
ec validate image \
    --image quay.io/redhat-user-workloads/jobset-lws-pipeline-tenant/lws-operator-main/lws-operator-bundle-main@sha256:abdf872decb2f844e7bb13422629bc58d5b883ca891f1b30d6a0b3ee65921103 \
    --policy '{"sources":[{"policy":["oci::quay.io/enterprise-contract/ec-release-policy:latest"]}]}' \
    --ignore-rekor \
    --skip-image-sig-check \
    --skip-att-sig-check \
    --certificate-identity-regexp '.*' \
    --certificate-oidc-issuer-regexp '.*' \
    --output text \
    --strict false \
    --info
    [Warning] github_certificate.gh_workflow_extensions
  ImageRef: quay.io/redhat-user-workloads/jobset-lws-pipeline-tenant/lws-operator-main/lws-operator-bundle-main@sha256:abdf872decb2f844e7bb13422629bc58d5b883ca891f1b30d6a0b3ee65921103
  Reason: Missing extension "GitHub Workflow SHA"
  Title: GitHub Workflow Certificate Extensions
  Description: Check if the image signature certificate contains the expected GitHub extensions. These are the extensions that
  represent the GitHub workflow trigger, sha, name, repository, and ref.

› [Warning] github_certificate.gh_workflow_extensions
  ImageRef: quay.io/redhat-user-workloads/jobset-lws-pipeline-tenant/lws-operator-main/lws-operator-bundle-main@sha256:abdf872decb2f844e7bb13422629bc58d5b883ca891f1b30d6a0b3ee65921103
  Reason: Missing extension "GitHub Workflow Trigger"
  Title: GitHub Workflow Certificate Extensions
  Description: Check if the image signature certificate contains the expected GitHub extensions. These are the extensions that
  represent the GitHub workflow trigger, sha, name, repository, and ref.

› [Warning] tasks.pipeline_required_tasks_list_provided
  ImageRef: quay.io/redhat-user-workloads/jobset-lws-pipeline-tenant/lws-operator-main/lws-operator-bundle-main@sha256:abdf872decb2f844e7bb13422629bc58d5b883ca891f1b30d6a0b3ee65921103
  Reason: Required tasks do not exist for pipeline
  Title: Required tasks list for pipeline was provided
  Description: Produce a warning if the required tasks list rule data was not provided.
  Solution: The required task list is contained as https://conforma.dev/docs/cli/configuration.html#_data_sources under the key
  'required-tasks'. Make sure this list exists.

› [Warning] test.no_test_warnings
  ImageRef: quay.io/redhat-user-workloads/jobset-lws-pipeline-tenant/lws-operator-main/lws-operator-bundle-main@sha256:abdf872decb2f844e7bb13422629bc58d5b883ca891f1b30d6a0b3ee65921103
  Reason: The Task "deprecated-image-check" from the build Pipeline reports a test contains warnings
  Term: deprecated-image-check
  Title: No tests produced warnings
  Description: Produce a warning if any tests have their result set to "WARNING". The result type is configurable by the
  "warned_tests_results" key in the rule data.
  Solution: There is a task with result 'TEST_OUTPUT' that returned a result of 'WARNING'. You can find which test resulted in
  'WARNING' by examining the 'result' key in the 'TEST_OUTPUT'. More information about the test should be available in the logs
  for the build Pipeline.
```
    
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Extended operator permissions to fully manage Kubernetes `NetworkPolicy` resources, including creating, updating, deleting, and monitoring changes.

* **Security / Access Updates**
  * Updated RBAC configuration to grant the operator the required `NetworkPolicy` access within the `networking.k8s.io` API group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->